### PR TITLE
Fix drawing coordinates to use canvas-relative positions

### DIFF
--- a/components/FrontPage/DrawingCanvas.js
+++ b/components/FrontPage/DrawingCanvas.js
@@ -13,8 +13,11 @@ const DrawingCanvas = ({ canvasRef, currentColor, brushSize, isEraser }) => {
 
   const startDrawing = (e) => {
     setIsDrawing(true);
-    setLastX(e.clientX);
-    setLastY(e.clientY);
+    const rect = canvasRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    setLastX(x);
+    setLastY(y);
   };
 
   const stopDrawing = () => {
@@ -36,12 +39,16 @@ const DrawingCanvas = ({ canvasRef, currentColor, brushSize, isEraser }) => {
       ctx.strokeStyle = currentColor;
     }
 
+    const rect = canvasRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
     ctx.moveTo(lastX, lastY);
-    ctx.lineTo(e.clientX, e.clientY);
+    ctx.lineTo(x, y);
     ctx.stroke();
 
-    setLastX(e.clientX);
-    setLastY(e.clientY);
+    setLastX(x);
+    setLastY(y);
   };
 
   return (


### PR DESCRIPTION
## Summary
- compute mouse positions relative to the canvas using `getBoundingClientRect`
- draw lines using canvas-relative coordinates

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be0a0abb2c8322b3ab7f96816631e3